### PR TITLE
feat(state-machine): add module, UI integration, model delegation, and build fixes

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/main.ts",
     "start": "node dist/main.js",
-    "build": "tsc -p tsconfig.build.json",
+    "build": "pnpm --filter @ai-dungeon-master/models build && tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "test": "jest --runInBand"
   },

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -2,9 +2,10 @@
 
 import { ChatModule } from './modules/chat/chat.module';
 import { CharacterCreationModule } from './modules/character-creation/character-creation.module';
+import { StateMachineModule } from './modules/state-machine/state-machine.module';
 
 @Module({
-  imports: [ChatModule, CharacterCreationModule],
+  imports: [ChatModule, CharacterCreationModule, StateMachineModule],
 })
 export class AppModule {}
 

--- a/apps/api/src/modules/character-creation/character-creation.delegation.spec.ts
+++ b/apps/api/src/modules/character-creation/character-creation.delegation.spec.ts
@@ -1,0 +1,34 @@
+import { CharacterCreationService } from './character-creation.service';
+
+describe('CharacterCreationService - delegation via model', () => {
+  it('delegates numeric field (ac) to model suggestions', async () => {
+    const mockExtractor = {
+      extractCharacterUpdate: async () => ({}),
+      detectDelegation: async () => true,
+      suggestCharacterValues: async () => ({ ac: 12 }),
+    } as any;
+
+    const service = new CharacterCreationService(mockExtractor);
+    const draft = service.createEmptyDraft();
+
+    const res = await service.applyAnswerToDraft(draft, 'ac', "I don't care");
+    expect(res.error).toBeUndefined();
+    expect(res.draft.ac).toBe(12);
+  });
+
+  it('delegates backstory generation to the model', async () => {
+    const mockExtractor = {
+      extractCharacterUpdate: async () => ({}),
+      detectDelegation: async () => true,
+      suggestCharacterValues: async () => ({ backstory: 'Born under a crimson moon, seeking lost lore.' }),
+    } as any;
+
+    const service = new CharacterCreationService(mockExtractor);
+    const draft = service.createEmptyDraft();
+
+    const res = await service.applyAnswerToDraft(draft, 'backstory', 'you decide');
+    expect(res.error).toBeUndefined();
+    expect(typeof res.draft.backstory).toBe('string');
+    expect((res.draft.backstory as string).length).toBeGreaterThan(0);
+  });
+});

--- a/apps/api/src/modules/character-creation/detect-delegation.spec.ts
+++ b/apps/api/src/modules/character-creation/detect-delegation.spec.ts
@@ -1,0 +1,25 @@
+import { ExtractionService } from './extraction.service';
+
+class CapturingChatService {
+  public lastMessages: { role: 'user' | 'assistant' | 'system'; content: string }[] = [];
+  constructor(private reply: string) {}
+  async sendChat(payload: { messages: any; systemPrompt?: string }): Promise<{ content: string }> {
+    this.lastMessages = payload.messages;
+    return { content: this.reply };
+  }
+}
+
+describe('ExtractionService.detectDelegation', () => {
+  it('uses only the last user input (single message)', async () => {
+    const chat = new CapturingChatService('{"delegated": true}') as any;
+    const svc = new ExtractionService(chat);
+    const delegated = await svc.detectDelegation("you decide the armor class", 'ac');
+
+    expect(delegated).toBe(true);
+    expect(Array.isArray((chat as any).lastMessages)).toBe(true);
+    expect((chat as any).lastMessages).toHaveLength(1);
+    expect((chat as any).lastMessages[0].role).toBe('user');
+    expect((chat as any).lastMessages[0].content).toContain('armor class');
+  });
+});
+

--- a/apps/api/src/modules/character-creation/extraction.service.ts
+++ b/apps/api/src/modules/character-creation/extraction.service.ts
@@ -1,7 +1,8 @@
-﻿import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 
 import { ChatService } from '../chat/chat.service';
-import type { CharacterField, CharacterUpdate, Ability } from '@ai-dungeon-master/models';
+import type { ChatMessageDto } from '../chat/dto/chat-message.dto';
+import type { CharacterField, CharacterUpdate, Ability, CharacterDraft } from '@ai-dungeon-master/models';
 
 const abilityKeys: Ability[] = ['STR', 'DEX', 'CON', 'INT', 'WIS', 'CHA'];
 
@@ -10,12 +11,10 @@ export class ExtractionService {
   private readonly logger = new Logger(ExtractionService.name);
   constructor(private readonly chat: ChatService) {}
 
-  async extractCharacterUpdate(text: string, expected: CharacterField[]): Promise<CharacterUpdate> {
+  async extractCharacterUpdate(text: string, expected: CharacterField[], history?: { role: 'user'|'assistant'|'system'; content: string }[]): Promise<CharacterUpdate> {
     const systemPrompt = this.buildSystemPrompt(expected);
-    const { content } = await this.chat.sendChat({
-      messages: [{ role: 'user', content: text }],
-      systemPrompt,
-    });
+    const messages = ((history && history.length) ? history : [{ role: 'user', content: text }]) as unknown as ChatMessageDto[];
+    const { content } = await this.chat.sendChat({ messages, systemPrompt });
 
     const json = this.firstJsonObject(content);
     if (!json) return {};
@@ -29,6 +28,56 @@ export class ExtractionService {
     }
   }
 
+  /**
+   * When the user delegates a choice (e.g., "you decide", "random", "auto"),
+   * ask the model to propose plausible values for the requested fields.
+   */
+  async suggestCharacterValues(expected: CharacterField[], draft?: CharacterDraft, history?: { role: 'user'|'assistant'|'system'; content: string }[]): Promise<CharacterUpdate> {
+    const systemPrompt = this.buildSuggestionPrompt(expected);
+    const userPayload = [
+      'Suggest appropriate values for the requested fields based on typical low-level fantasy RPG characters.',
+      draft ? `Current partial draft: ${JSON.stringify(this.minifyDraft(draft))}` : undefined,
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    const messages = ((history && history.length) ? history : [{ role: 'user', content: userPayload }]) as unknown as ChatMessageDto[];
+    const { content } = await this.chat.sendChat({ messages, systemPrompt });
+
+    const json = this.firstJsonObject(content);
+    if (!json) return {};
+    try {
+      const raw = JSON.parse(json) as Record<string, unknown>;
+      return this.normalizeUpdate(raw);
+    } catch (err) {
+      this.logger.warn(`Failed to parse suggestion JSON`, err as Error);
+      return {};
+    }
+  }
+
+  /**
+   * Classify if the user is delegating the choice for the given field.
+   * Returns true when delegating, false otherwise.
+   */
+    async detectDelegation(
+    text: string,
+    field?: CharacterField,
+    _history?: { role: 'user' | 'assistant' | 'system'; content: string }[],
+  ): Promise<boolean> {
+    const systemPrompt = this.buildDelegationPrompt(field);
+    // For delegation classification, only the last user input is required.
+    const messages = [{ role: 'user', content: text }] as unknown as import('../chat/dto/chat-message.dto').ChatMessageDto[];
+    const { content } = await this.chat.sendChat({ messages, systemPrompt });
+    const json = this.firstJsonObject(content);
+    if (!json) return false;
+    try {
+      const parsed = JSON.parse(json) as { delegated?: boolean };
+      return parsed?.delegated === true;
+    } catch {
+      return false;
+    }
+  }
+
   private buildSystemPrompt(expected: CharacterField[]): string {
     const keys = expected; // restrict to requested fields
     return [
@@ -38,6 +87,41 @@ export class ExtractionService {
       'For abilities, use an object with keys ["STR","DEX","CON","INT","WIS","CHA"] and numeric values.',
       'For missing values, omit the key.',
     ].join(' ');
+  }
+
+  private buildDelegationPrompt(field?: CharacterField): string {
+    const fieldText = field ? ` for the field "${field}"` : '';
+    return [
+      'You are a strict classifier.',
+      `Task: Determine if the user is delegating the decision${fieldText}.`,
+      'Delegation means the user asks the DM/app to pick a value (e.g., "you decide", "whatever", "random", "I don\'t care").',
+      'Return ONLY minified JSON: {"delegated": true|false}. No extra text, no code fences.',
+    ].join(' ');
+  }
+
+  private buildSuggestionPrompt(expected: CharacterField[]): string {
+    const keys = expected;
+    const wants = (k: CharacterField) => keys.includes(k);
+    const lines: string[] = [];
+    lines.push('You propose plausible character values when the user delegates.');
+    lines.push('Return ONLY minified JSON with only the requested keys (no code fences, no extra text).');
+    lines.push(`Keys required from this set: ${JSON.stringify(keys)}.`);
+    if (wants('level')) lines.push('For "level": 1-20, prefer 1-3 by default.');
+    if (wants('ac')) lines.push('For "ac": integer >=5, prefer 10-16 by default.');
+    if (wants('maxHP')) lines.push('For "maxHP": integer 1-999.');
+    if (wants('hp')) lines.push('For "hp": integer 1-999 and hp <= maxHP when both present.');
+    if (wants('abilities'))
+      lines.push('For "abilities": object with keys ["STR","DEX","CON","INT","WIS","CHA"] and values 3-18.');
+    if (wants('name')) lines.push('For "name": a concise fantasy-style name (string).');
+    if (wants('race')) lines.push('For "race": a typical fantasy race (string), e.g., Human, Elf, Dwarf.');
+    if (wants('class')) lines.push('For "class": a typical class (string), e.g., Fighter, Wizard, Rogue.');
+    if (wants('backstory')) lines.push('For "backstory": a brief flavorful paragraph under 100 words (string).');
+    return lines.join(' ');
+  }
+
+  private minifyDraft(draft: CharacterDraft) {
+    const { name, race, class: clazz, level, ac, maxHP, hp } = draft as any;
+    return { name, race, class: clazz, level, ac, maxHP, hp };
   }
 
   private firstJsonObject(text: string): string | null {
@@ -94,6 +178,9 @@ const clamp = (value: number, min: number, max: number) => {
   if (Number.isNaN(value)) return min;
   return Math.max(min, Math.min(max, value));
 };
+
+
+
 
 
 

--- a/apps/api/src/modules/state-machine/dto/state-input.dto.ts
+++ b/apps/api/src/modules/state-machine/dto/state-input.dto.ts
@@ -1,0 +1,10 @@
+import { IsString } from 'class-validator';
+
+export class StateInputDto {
+  @IsString()
+  sessionId!: string;
+
+  @IsString()
+  message!: string;
+}
+

--- a/apps/api/src/modules/state-machine/dto/state-response.dto.ts
+++ b/apps/api/src/modules/state-machine/dto/state-response.dto.ts
@@ -1,0 +1,11 @@
+import type { CharacterDraft } from '@ai-dungeon-master/models';
+import { SessionPhase } from '../interfaces/state';
+
+export class StateResponseDto {
+  sessionId!: string;
+  phase!: SessionPhase;
+  output!: string;
+  draft?: CharacterDraft;
+  pendingField?: string;
+}
+

--- a/apps/api/src/modules/state-machine/interfaces/state.ts
+++ b/apps/api/src/modules/state-machine/interfaces/state.ts
@@ -1,0 +1,31 @@
+import type { CharacterDraft, CharacterField } from '@ai-dungeon-master/models';
+
+export enum SessionPhase {
+  CHARACTER_CREATION = 'CHARACTER_CREATION',
+  EXPLORING = 'EXPLORING',
+}
+
+export type ConversationMessage = { role: 'user' | 'assistant' | 'system'; content: string };
+
+export interface SessionContext {
+  sessionId: string;
+  campaignId?: string;
+  draft?: CharacterDraft;
+  pendingField?: CharacterField;
+  history?: ConversationMessage[];
+}
+
+export interface TransitionInput {
+  message: string;
+}
+
+export interface TransitionResult {
+  nextPhase: SessionPhase;
+  output: string;
+  context: SessionContext;
+}
+
+export interface StateHandler {
+  readonly phase: SessionPhase;
+  transition(ctx: SessionContext, input: TransitionInput): Promise<TransitionResult>;
+}

--- a/apps/api/src/modules/state-machine/state-machine.controller.ts
+++ b/apps/api/src/modules/state-machine/state-machine.controller.ts
@@ -1,0 +1,22 @@
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+
+import { StateMachineService } from './state-machine.service';
+import { StateInputDto } from './dto/state-input.dto';
+import { StateResponseDto } from './dto/state-response.dto';
+
+@Controller('state-machine')
+export class StateMachineController {
+  constructor(private readonly sm: StateMachineService) {}
+
+  @Post('step')
+  async step(@Body() body: StateInputDto): Promise<StateResponseDto> {
+    const res = await this.sm.step(body.sessionId, body.message);
+    return res as StateResponseDto;
+  }
+
+  @Get(':sessionId')
+  async get(@Param('sessionId') sessionId: string) {
+    return this.sm.getSession(sessionId) ?? { sessionId, phase: null };
+  }
+}
+

--- a/apps/api/src/modules/state-machine/state-machine.module.ts
+++ b/apps/api/src/modules/state-machine/state-machine.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+
+import { StateMachineService } from './state-machine.service';
+import { StateMachineController } from './state-machine.controller';
+import { CharacterCreationModule } from '../character-creation/character-creation.module';
+import { ChatModule } from '../chat/chat.module';
+import { CharacterCreationState } from './states/character-creation.state';
+import { ExploringState } from './states/exploring.state';
+
+@Module({
+  imports: [CharacterCreationModule, ChatModule],
+  controllers: [StateMachineController],
+  providers: [StateMachineService, CharacterCreationState, ExploringState],
+})
+export class StateMachineModule {}

--- a/apps/api/src/modules/state-machine/state-machine.service.ts
+++ b/apps/api/src/modules/state-machine/state-machine.service.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@nestjs/common';
+
+import { CharacterCreationState } from './states/character-creation.state';
+import { ExploringState } from './states/exploring.state';
+import { SessionContext, SessionPhase, ConversationMessage } from './interfaces/state';
+
+@Injectable()
+export class StateMachineService {
+  private readonly sessions = new Map<string, { phase: SessionPhase; ctx: SessionContext }>();
+
+  constructor(
+    private readonly characterCreation: CharacterCreationState,
+    private readonly exploring: ExploringState,
+  ) {}
+
+  async step(sessionId: string, message: string) {
+    const existing = this.sessions.get(sessionId) ?? {
+      phase: SessionPhase.CHARACTER_CREATION,
+      ctx: { sessionId, history: [] as ConversationMessage[] },
+    };
+    const history = existing.ctx.history ?? [];
+    const withUser: SessionContext = {
+      ...existing.ctx,
+      history: history.concat([{ role: 'user', content: message }]),
+    };
+
+    const handler = this.getHandler(existing.phase);
+    const { nextPhase, output, context } = await handler.transition(withUser, { message });
+
+    const nextHistory = (context.history ?? withUser.history ?? []).concat([
+      { role: 'assistant', content: output },
+    ]);
+    const nextCtx: SessionContext = { ...context, history: nextHistory };
+
+    this.sessions.set(sessionId, { phase: nextPhase, ctx: nextCtx });
+
+    return {
+      sessionId,
+      phase: nextPhase,
+      output,
+      draft: nextCtx.draft,
+      pendingField: nextCtx.pendingField,
+    };
+  }
+
+  getSession(sessionId: string) {
+    const s = this.sessions.get(sessionId);
+    if (!s) return null;
+    return { sessionId, phase: s.phase, draft: s.ctx.draft, pendingField: s.ctx.pendingField };
+  }
+
+  private getHandler(phase: SessionPhase) {
+    switch (phase) {
+      case SessionPhase.CHARACTER_CREATION:
+        return this.characterCreation;
+      case SessionPhase.EXPLORING:
+        return this.exploring;
+      default:
+        return this.characterCreation;
+    }
+  }
+}

--- a/apps/api/src/modules/state-machine/states/character-creation.state.ts
+++ b/apps/api/src/modules/state-machine/states/character-creation.state.ts
@@ -1,0 +1,93 @@
+import { Injectable } from '@nestjs/common';
+
+import type { CharacterDraft, CharacterField } from '@ai-dungeon-master/models';
+import { CharacterCreationService } from '../../character-creation/character-creation.service';
+import { SessionPhase, StateHandler, TransitionInput, TransitionResult, SessionContext } from '../interfaces/state';
+
+@Injectable()
+export class CharacterCreationState implements StateHandler {
+  readonly phase = SessionPhase.CHARACTER_CREATION as const;
+
+  constructor(private readonly cc: CharacterCreationService) {}
+
+  async transition(ctx: SessionContext, input: TransitionInput): Promise<TransitionResult> {
+    const draft: CharacterDraft = ctx.draft ?? this.cc.createEmptyDraft();
+
+    // If we have a pending field, try to apply the answer
+    if (ctx.pendingField) {
+      const { draft: nextDraft, error } = await this.cc.applyAnswerToDraft(
+        draft,
+        ctx.pendingField,
+        input.message,
+        ctx.history,
+      );
+      if (error) {
+        const prompt = this.promptForField(ctx.pendingField);
+        return {
+          nextPhase: this.phase,
+          output: `${error}\n${prompt}`.trim(),
+          context: { ...ctx, draft: nextDraft, pendingField: ctx.pendingField },
+        };
+      }
+      ctx = { ...ctx, draft: nextDraft, pendingField: undefined };
+    }
+
+    // Decide next question or transition
+    if (this.cc.isDraftComplete(ctx.draft ?? draft)) {
+      const complete = this.cc.finalizeCharacter(ctx.draft ?? draft);
+      const summary = this.describeCharacter(complete);
+      return {
+        nextPhase: SessionPhase.EXPLORING,
+        output: `Character created! ${summary}\nEntering exploring phase...`,
+        context: { ...ctx, draft: complete },
+      };
+    }
+
+    const question = this.cc.getNextQuestion(ctx.draft ?? draft);
+    if (question) {
+      return {
+        nextPhase: this.phase,
+        output: question.prompt,
+        context: { ...ctx, draft: ctx.draft ?? draft, pendingField: question.field },
+      };
+    }
+
+    // Fallback (shouldn't happen): ask for name first
+    return {
+      nextPhase: this.phase,
+      output: this.promptForField('name'),
+      context: { ...ctx, draft: ctx.draft ?? draft, pendingField: 'name' },
+    };
+  }
+
+  private promptForField(field: CharacterField): string {
+    const q = this.cc.getNextQuestion({ ...this.cc.createEmptyDraft(), [field]: undefined } as CharacterDraft);
+    // Fallback to simple text if service doesn't provide
+    switch (field) {
+      case 'name':
+        return "What's the character's name?";
+      case 'race':
+        return 'What race is the character (e.g., Human, Elf, Dwarf)?';
+      case 'class':
+        return 'What class does the character belong to (e.g., Fighter, Wizard)?';
+      case 'level':
+        return 'What level is the character? (1-20)';
+      case 'abilities':
+        return "Provide ability scores for STR, DEX, CON, INT, WIS, CHA (e.g., '15 14 13 12 10 8') or say 'auto' for the standard array.";
+      case 'ac':
+        return "What is the character's armor class?";
+      case 'maxHP':
+        return "What is the character's maximum hit points?";
+      case 'hp':
+        return "What is the character's starting hit points?";
+      case 'backstory':
+        return 'Share a brief backstory (under 100 words).';
+      default:
+        return 'Please provide the requested character detail.';
+    }
+  }
+
+  private describeCharacter(pc: ReturnType<CharacterCreationService['finalizeCharacter']>): string {
+    return `${pc.name} the ${pc.race} ${pc.class} (Level ${pc.level}, AC ${pc.ac}, HP ${pc.hp}/${pc.maxHP}).`;
+  }
+}

--- a/apps/api/src/modules/state-machine/states/exploring.state.spec.ts
+++ b/apps/api/src/modules/state-machine/states/exploring.state.spec.ts
@@ -1,0 +1,32 @@
+import { ExploringState } from './exploring.state';
+
+class MockChatService {
+  public lastMessages: any[] | null = null;
+  constructor(private reply: string) {}
+  async sendChat(payload: { messages: any; systemPrompt?: string }): Promise<{ content: string }> {
+    this.lastMessages = payload.messages;
+    return { content: this.reply };
+  }
+}
+
+describe('ExploringState', () => {
+  it('sends conversation history to the model', async () => {
+    const chat = new MockChatService('The torchlight flickers against damp stone.');
+    const state = new ExploringState(chat as any);
+
+    const ctx = {
+      sessionId: 's1',
+      history: [
+        { role: 'assistant', content: 'You stand at a crossroads in a cavern.' },
+        { role: 'user', content: 'I head north.' },
+      ],
+    };
+
+    const res = await state.transition(ctx as any, { message: 'I light a torch.' });
+    expect(res.output).toContain('torch');
+    expect(Array.isArray((chat as any).lastMessages)).toBe(true);
+    expect((chat as any).lastMessages).toHaveLength(2);
+    expect((chat as any).lastMessages[0].role).toBe('assistant');
+  });
+});
+

--- a/apps/api/src/modules/state-machine/states/exploring.state.ts
+++ b/apps/api/src/modules/state-machine/states/exploring.state.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@nestjs/common';
+
+import { SessionPhase, StateHandler, TransitionInput, TransitionResult, SessionContext } from '../interfaces/state';
+import { ChatService } from '../../chat/chat.service';
+
+@Injectable()
+export class ExploringState implements StateHandler {
+  readonly phase = SessionPhase.EXPLORING as const;
+
+  constructor(private readonly chat: ChatService) {}
+
+  async transition(ctx: SessionContext, input: TransitionInput): Promise<TransitionResult> {
+    const trimmed = input.message?.trim() ?? '';
+    if (!trimmed) {
+      return {
+        nextPhase: this.phase,
+        output: 'You are exploring. What do you do?',
+        context: ctx,
+      };
+    }
+
+    const systemPrompt = this.buildSystemPrompt(ctx);
+    const { content } = await this.chat.sendChat({
+      messages: ctx.history && ctx.history.length ? ctx.history : [{ role: 'user', content: trimmed }],
+      systemPrompt,
+    });
+
+    return {
+      nextPhase: this.phase,
+      output: content ?? '',
+      context: ctx,
+    };
+  }
+
+  private buildSystemPrompt(ctx: SessionContext): string {
+    const base =
+      'You are an imaginative but concise dungeon master guiding exploration. Keep every reply under 30 words.';
+    const draft = ctx.draft;
+    if (!draft) return base;
+    const parts: string[] = [base, 'Player character context:'];
+    if (draft.name) parts.push(`Name: ${draft.name}`);
+    if (draft.race) parts.push(`Race: ${draft.race}`);
+    if (draft.class) parts.push(`Class: ${draft.class}`);
+    if (draft.level) parts.push(`Level: ${draft.level}`);
+    if (draft.ac) parts.push(`AC: ${draft.ac}`);
+    if (draft.maxHP !== undefined && draft.hp !== undefined) parts.push(`HP: ${draft.hp}/${draft.maxHP}`);
+    return parts.join(' ');
+  }
+}
+

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,8 +1,17 @@
 ﻿{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "declaration": true,
-    "sourceMap": false
+    "extends":  "./tsconfig.json",
+    "compilerOptions":  {
+                            "declaration":  true,
+                            "sourceMap": false,
+    "paths": {
+      "@ai-dungeon-master/models": ["../../packages/models/dist"],
+      "@ai-dungeon-master/models/*": ["../../packages/models/dist/*"]
+    }
   },
-  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts", "src/test.ts"]
+    "exclude":  [
+                    "src/**/*.spec.ts",
+                    "src/**/*.test.ts",
+                    "src/test.ts"
+                ]
 }
+

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -21,7 +21,7 @@
                                     ],
                             "moduleResolution":  "node",
                             "baseUrl":  "../../",
-                            "paths": { "@ai-dungeon-master/models": ["packages/models/src"], "@ai-dungeon-master/models/*": ["packages/models/src/*"], "@ai-dungeon-master/engine": ["packages/engine/src"], "@ai-dungeon-master/orchestrator": ["packages/orchestrator/src"], "@ai-dungeon-master/storage": ["packages/storage/src"], "@ai-dungeon-master/ui": ["packages/ui/src"] }
+                            "paths": { "@ai-dungeon-master/models": ["packages/models/dist"], "@ai-dungeon-master/models/*": ["packages/models/dist/*"], "@ai-dungeon-master/engine": ["packages/engine/src"], "@ai-dungeon-master/orchestrator": ["packages/orchestrator/src"], "@ai-dungeon-master/storage": ["packages/storage/src"], "@ai-dungeon-master/ui": ["packages/ui/src"] }
                         },
     "include":  [
                     "src/**/*"

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -27,6 +27,7 @@ export default function Home() {
           placeholder="Describe your next move or ask for a plot twist..."
           apiBaseUrl={apiBaseUrl}
           systemPrompt={systemPrompt}
+          useStateMachine
         />
       </main>
     </div>


### PR DESCRIPTION
This PR introduces a new state-machine flow and wires it across the API and UI.

Highlights
- State machine in API with CharacterCreation + Exploring states
- Session tracking with in-memory `sessionId -> { phase, context, history }`
- Model-driven delegation (including backstory) + suggestions
- Full conversation history passed to extraction/exploring
- UI updated to use `/api/state-machine/step` with a static intro
- API build fixed to consume compiled `@ai-dungeon-master/models` types
- Tests added for delegation, exploring history, and classifier behavior

Notes
- Exploring uses `ChatService`; ensure `OLLAMA_ENDPOINT` is reachable
- Dev: Web on 3000, API on 3001 (CORS_ORIGIN can allow http://localhost:3000)